### PR TITLE
use node:10-alpine image and add components libraries during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:10-alpine
 
 RUN mkdir /opt/presentation/
 
@@ -7,6 +7,7 @@ WORKDIR /opt/presentation/
 COPY deck.mdx .
 COPY package-lock.json .
 COPY package.json .
+COPY component/ ./component/
 
 RUN npm install
 


### PR DESCRIPTION
this commit uses lighter node:10-alpine. It stripped off irrelevant program in the image itself. It is also reorganizes libraries needed during build.